### PR TITLE
Convert type of $response from stdclass to array

### DIFF
--- a/src/Oauth2/Client/Provider/Spotify.php
+++ b/src/Oauth2/Client/Provider/Spotify.php
@@ -53,7 +53,8 @@ class Spotify extends AbstractProvider
         $this->headers = array(
             'Authorization' => sprintf('Bearer %s', $token->accessToken)
         );
-
+        
+        $response = json_decode(json_encode($response), true);
         $user = new User();
         $user->uid = $response['id'];
         $user->name = $response['display_name'];


### PR DESCRIPTION
$response sometimes returns stdclass object insteat of associative array and we need to convert it to array instead
Reason: The function getUserDetails in "League\OAuth2\Client\Provider\AbstractProvider" passes the result of json_decode, which is now a std class object.