### PR TITLE
Avoid warnings when proper scope not included

### DIFF
--- a/src/Oauth2/Client/Provider/Spotify.php
+++ b/src/Oauth2/Client/Provider/Spotify.php
@@ -57,7 +57,7 @@ class Spotify extends AbstractProvider
         $user = new User();
         $user->uid = $response['id'];
         $user->name = $response['display_name'];
-        $user->email = $response['email'];
+        $user->email = !empty($response['email']) ? $response['email'] : null;
         $user->imageUrl = isset($response['images'][0]['url']) ?: null;
         $user->urls = $response['external_urls'];
 


### PR DESCRIPTION
If the scopes does not include "user-read-email", the "email" field will be empty in response and will cause an a notice "Notice: Undefined index: email in src/Oauth2/Client/Provider/Spotify.php on line 59".