### PR TITLE
Catch additional prams in user details response

### DIFF
--- a/src/Oauth2/Client/Provider/Spotify.php
+++ b/src/Oauth2/Client/Provider/Spotify.php
@@ -13,6 +13,13 @@ class Spotify extends AbstractProvider
 {
 
     public $scopeSeparator = ' ';
+    protected $birthdate, $country, $followers, $product;
+
+    const PARAM_BIRTHDATE = 'birthdate';
+    const PARAM_COUNTRY = 'country';
+    const PARAM_FOLLOWERS = 'followers';
+    const PARAM_PRODUCT = 'product';
+    const PRODUCT_PREMIUM = 'premium';
 
     /**
      * @return string
@@ -55,6 +62,7 @@ class Spotify extends AbstractProvider
         );
         
         $response = json_decode(json_encode($response), true);
+        $this->setAdditionalParams($response);
         $user = new User();
         $user->uid = $response['id'];
         $user->name = $response['display_name'];
@@ -63,5 +71,42 @@ class Spotify extends AbstractProvider
         $user->urls = $response['external_urls'];
 
         return $user;
+    }
+    
+    /**
+     * Sets additional parametes being returned from "me" endpoint when additional scopes are available
+     * @param $response
+     */
+    public function setAdditionalParams($response)
+    {
+        $this->birthdate = !empty($response[self::PARAM_BIRTHDATE]) ? $response[self::PARAM_BIRTHDATE] : null;
+        $this->country = !empty($response[self::PARAM_COUNTRY]) ? $response[self::PARAM_COUNTRY] : null;
+        $this->followers = !empty($response[self::PARAM_FOLLOWERS]) ? $response[self::PARAM_FOLLOWERS] : null;
+        $this->product = !empty($response[self::PARAM_PRODUCT]) ? $response[self::PARAM_PRODUCT] : null;
+    }
+    
+    /**
+     * Checks if user has a premium account
+     */
+    public function isPremium()
+    {
+        return ($this->product == self::PRODUCT_PREMIUM);
+    }
+
+    
+    /**
+     * Returns country of user if available
+     */
+    public function country()
+    {
+        return !empty($this->country) ? $this->country : null;
+    }
+    
+    /**
+     * Returns followers if available
+     */
+    public function followers()
+    {
+        return !empty($this->followers) ? $this->followers : null;
     }
 }


### PR DESCRIPTION
When the access token has more scope of access, the user details endpoint will return additional data than catch in the function userDetails. 
Additional params includes following
- birthdate
- country
- followers
- product

Also we can use these details to check if the user has **premium account**.

Response of user details request when access token has more scopes including following

- user-read-private
- user-read-birthdate
- user-read-email

stdClass object {
  birthdate => (string) 1984-03-23
  country => (string) GB
  display_name => null
  email => (string) xxx@xxx.com
  external_urls => stdClass object {
    spotify => (string) https://open.spotify.com/user/xxx
  }
  followers => stdClass object {
    href => null
    total => (int) 0
  }
  href => (string) https://api.spotify.com/v1/users/xxx
  id => (string) xxx
  images => array(1) (
    [0] => stdClass object {
      height => null
      url => (string) https://profile-images.scdn.co/images/userprofile/default/xxx
      width => null
    }
  )
  product => (string) premium
  type => (string) user
  uri => (string) spotify:user:xxx
}